### PR TITLE
Removed this from sortByOptionValue and sortByOption in return statem…

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -11,7 +11,7 @@ class SearchBar extends React.Component {
   renderSortByOptions() { // purpose of renderSortByOptions() is to dynamically create the list items needed to display the sort options (Best Match, Highest Rated, Most Reviewed), to help future proof against potential changes to the Yelp API.
     return Object.keys(sortByOptions).map(sortByOption => {
       let sortByOptionValue = sortByOptions[sortByOption]; // Inside of the callback function, access the sortByOptions values using the sortByOption parameter of the callback function. Store values in variable called sortByOptionValue.
-      return <li key={this.sortByOptionValue}>{this.sortByOption}</li>;
+      return <li key={sortByOptionValue}>{sortByOption}</li>;
     });
   }
 


### PR DESCRIPTION
…ent in renderSortByOptions, since the two variables are defined in the same class in the line above